### PR TITLE
delete mrb_longjmp from mruby.def

### DIFF
--- a/mruby.def
+++ b/mruby.def
@@ -150,7 +150,6 @@ EXPORTS
 	mrb_load_nstring_cxt
 	mrb_load_string
 	mrb_load_string_cxt
-	mrb_longjmp
 	mrb_make_exception
 	mrb_mod_class_variables
 	mrb_mod_constants


### PR DESCRIPTION
Current mruby was deleted mrb_longjmp.
So I deleted it.
