### PR TITLE
Don't export `mrb_str_buf_cat`

### DIFF
--- a/mruby.def
+++ b/mruby.def
@@ -211,7 +211,6 @@ EXPORTS
 	mrb_singleton_class
 	mrb_str_append
 	mrb_str_buf_append
-	mrb_str_buf_cat
 	mrb_str_buf_new
 	mrb_str_cat
 	mrb_str_cat_cstr


### PR DESCRIPTION
Don't export `mrb_str_buf_cat` which was inlined in mruby/mruby@bc23a5e9e555f7a0b606856c417b9910ed92af68.
