### PR TITLE
Allow ARM and X64 Builds

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -30,6 +30,7 @@ MRuby.each_target do
     gem_flags = gems.map { |g| g.linker.flags }
     gem_flags << (is_vc ? '/DLL' : '-shared')
     gem_flags << (is_vc ? "/DEF:#{deffile}" : mruby_sharedlib_ext == 'dylib'? '-Wl,-force_load' : is_mingw ? deffile : "-Wl,--whole-archive")
+    gem_flags << "/MACHINE:#{ENV['Platform']}" if is_vc && ENV['Platform']
     gem_flags += t.prerequisites
     gem_libraries = gems.map { |g| g.linker.libraries }
     gem_library_paths = gems.map { |g| g.linker.library_paths }


### PR DESCRIPTION
When building DLLs, LINK.exe requires a /MACHINE option. This enables x64 builds by using the Platform ENV set in the VS Tool's 'x64 Command Prompt' to determine which machine to link for.

No guarantee x64 builds are a viable option for mruby, this just ensures x64 DLLs.
